### PR TITLE
Feature detection by constants to allow some autocompletion in IDE's

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ switch(Morse::featureExists('file/finfo')) {
 }
 ```
 
+The names of the available feature detections are also available as a constant on the Morse class:
+
+```php
+if (Morse::featureExists(Morse::FEATURE_FILE_FINFO)) {
+	...
+}
+```
+
 If class support is found, this returns regardless of function support.
 
 

--- a/src/Morse.php
+++ b/src/Morse.php
@@ -6,6 +6,53 @@ class Morse
 	const CLASS_SUPPORT = 1;
 	const FUNCTION_SUPPORT = 2;
 
+    const FEATURE_CACHE_MEMCACHE = 'cache/memcache';
+    const FEATURE_CACHE_MEMCACHED = 'cache/memcached';
+    const FEATURE_CACHE_APC = 'cache/apc';
+    const FEATURE_CACHE_OPCACHE = 'cache/opcache';
+
+    const FEATURE_CRYPTO_MCRYPT = 'crypto/mcrypt';
+    const FEATURE_CRYPTO_OPENSSL = 'crypto/openssl';
+    const FEATURE_CRYPTO_PASSWORD = 'crypto/password';
+
+    const FEATURE_DB_MYSQLI = 'db/mysqli';
+    const FEATURE_DB_PDO = 'db/pdo';
+    const FEATURE_DB_PDO_MYSQL = 'db/pdo-mysql';
+    const FEATURE_DB_PDO_PGSQL = 'db/pdo-pgsql';
+    const FEATURE_DB_PDO_SQLITE = 'db/pdo-sqlite';
+
+    const FEATURE_FILE_FINFO = 'file/finfo';
+    const FEATURE_FILE_ZIP = 'file/zip';
+
+    const FEATURE_HTTP_CURL = 'http/curl';
+    const FEATURE_HTTP_FILTER = 'http/filter';
+    const FEATURE_HTTP_OPENSSL = 'http/openssl';
+    const FEATURE_HTTP_SOCKETS = 'http/sockets';
+
+    const FEATURE_IMAGE_GD = 'image/gd';
+    const FEATURE_IMAGE_IMAGICK = 'image/imagick';
+
+    const FEATURE_NUMBER_BIGINT = 'number/bigint';
+
+    const FEATURE_PROTOCOL_LDAP = 'protocol/ldap';
+
+    const FEATURE_STRING_CTYPE = 'string/ctype';
+    const FEATURE_STRING_ICONV = 'string/iconv';
+    const FEATURE_STRING_INTL = 'string/intl';
+    const FEATURE_STRING_JSON = 'string/json';
+    const FEATURE_STRING_MULTIBYTE = 'string/multibyte';
+    const FEATURE_STRING_TRANSLITERATE = 'string/transliterate';
+
+    const FEATURE_SYSTEM_EXEC = 'system/exec';
+    const FEATURE_SYSTEM_IGNORE_USER_ABORT = 'system/ignore-user-abort';
+    const FEATURE_SYSTEM_INI_SET = 'system/ini-set';
+    const FEATURE_SYSTEM_PASSTHRU = 'system/passthru';
+    const FEATURE_SYSTEM_POPEN = 'system/popen';
+    const FEATURE_SYSTEM_PROC_OPEN = 'system/proc-open';
+    const FEATURE_SYSTEM_SET_TIME_LIMIT = 'system/set-time-limit';
+    const FEATURE_SYSTEM_SHELL_EXEC = 'system/shell-exec';
+    const FEATURE_SYSTEM_SYSTEM = 'system/system';
+
 	/**
 	 * In-memory cache of disabled functions names.
 	 */

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -6,25 +6,25 @@ class CacheTest extends PHPUnit_Framework_TestCase
 {
 	public function testMemcache()
 	{
-		$result = Morse::featureExists('cache/memcache');
+		$result = Morse::featureExists(Morse::FEATURE_CACHE_MEMCACHE);
 		$this->assertTrue($result===true || $result===false);
 	}
 
 	public function testMemcached()
 	{
-		$result = Morse::featureExists('cache/memcached');
+		$result = Morse::featureExists(Morse::FEATURE_CACHE_MEMCACHED);
 		$this->assertTrue($result===true || $result===false);
 	}
 
 	public function testApc()
 	{
-		$result = Morse::featureExists('cache/apc');
+		$result = Morse::featureExists(Morse::FEATURE_CACHE_APC);
 		$this->assertTrue($result===true || $result===false);
 	}
 
 	public function testOpcache()
 	{
-		$result = Morse::featureExists('cache/opcache');
+		$result = Morse::featureExists(Morse::FEATURE_CACHE_OPCACHE);
 		$this->assertTrue($result===true || $result===false);
 	}
 

--- a/tests/ConstantsTest.php
+++ b/tests/ConstantsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use DrewM\Morse\Morse;
+
+class ConstantsTest extends PHPUnit_Framework_TestCase
+{
+    private $morseClass = 'DrewM\Morse\Morse';
+
+    /**
+     * Check if all feature test methods are provided with a constant on the Morse class for IDE autocompletion
+     */
+    public function testMorseClassHasFeatureConstants()
+    {
+        $reflectionClass = new ReflectionClass($this->morseClass);
+        $constants = $reflectionClass->getConstants();
+        $excludedMethods = array('testfake_negative', 'testfake_positive');
+
+        $featureClasses = glob(dirname(__FILE__) . '/../src/Feature/*.php');
+        foreach($featureClasses as $featureClass){
+            $methodClassName = strtolower(pathinfo($featureClass, PATHINFO_FILENAME));
+            $methodClassId = strtolower($methodClassName);
+
+            $feature = new ReflectionClass(sprintf('DrewM\Morse\Feature\\%s', $methodClassName));
+            foreach($feature->getMethods(ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED) as $reflectionMethod){
+                $funcName = strtolower($reflectionMethod->getName());
+                if(!in_array($funcName, $excludedMethods) && substr($funcName, 0, 4) == 'test'){
+                    $methodId = $methodClassId . '/' . substr($funcName, 4);
+                    $constantName = sprintf('FEATURE_%s', strtoupper(str_replace('/', '_', $methodId)));
+
+                    $this->assertArrayHasKey($constantName, $constants);
+                    $this->assertEquals(str_replace('_','-',$methodId), str_replace('_','-',$constants[$constantName]));
+                }
+            }
+        }
+    }
+}

--- a/tests/ConstantsTest.php
+++ b/tests/ConstantsTest.php
@@ -17,7 +17,7 @@ class ConstantsTest extends PHPUnit_Framework_TestCase
 
         $featureClasses = glob(dirname(__FILE__) . '/../src/Feature/*.php');
         foreach($featureClasses as $featureClass){
-            $methodClassName = strtolower(pathinfo($featureClass, PATHINFO_FILENAME));
+            $methodClassName = pathinfo($featureClass, PATHINFO_FILENAME);
             $methodClassId = strtolower($methodClassName);
 
             $feature = new ReflectionClass(sprintf('DrewM\Morse\Feature\\%s', $methodClassName));

--- a/tests/CryptoTest.php
+++ b/tests/CryptoTest.php
@@ -6,19 +6,19 @@ class CryptoTest extends PHPUnit_Framework_TestCase
 {
 	public function testOpenssl()
 	{
-		$result = Morse::featureExists('crypto/openssl');
+		$result = Morse::featureExists(Morse::FEATURE_CRYPTO_OPENSSL);
 		$this->assertTrue($result===true || $result===false);
 	}
 
 	public function testMcrypt()
 	{
-		$result = Morse::featureExists('crypto/mcrypt');
+		$result = Morse::featureExists(Morse::FEATURE_CRYPTO_MCRYPT);
 		$this->assertTrue($result===true || $result===false);
 	}
 
 	public function testPassword()
 	{
-		$result = Morse::featureExists('crypto/password');
+		$result = Morse::featureExists(Morse::FEATURE_CRYPTO_PASSWORD);
 		$this->assertTrue($result===true || $result===false);
 	}
 }

--- a/tests/DbTest.php
+++ b/tests/DbTest.php
@@ -6,31 +6,31 @@ class DbTest extends PHPUnit_Framework_TestCase
 {
 	public function testPdo()
 	{
-		$result = Morse::featureExists('db/pdo');
+		$result = Morse::featureExists(Morse::FEATURE_DB_PDO);
 		$this->assertTrue($result===true || $result===false);
 	}
 
 	public function testPdo_Mysql()
 	{
-		$result = Morse::featureExists('db/pdo-mysql');
+		$result = Morse::featureExists(Morse::FEATURE_DB_PDO_MYSQL);
 		$this->assertTrue($result===true || $result===false);
 	}
 
 	public function testPdo_Sqlite()
 	{
-		$result = Morse::featureExists('db/pdo-sqlite');
+		$result = Morse::featureExists(Morse::FEATURE_DB_PDO_SQLITE);
 		$this->assertTrue($result===true || $result===false);
 	}
 
-	public function testPdo_Mysqli()
+	public function testMysqli()
 	{
-		$result = Morse::featureExists('db/mysqli');
+		$result = Morse::featureExists(Morse::FEATURE_DB_MYSQLI);
 		$this->assertTrue($result===true || $result===false);
 	}
 
 	public function testPdo_Pgsql()
 	{
-		$result = Morse::featureExists('db/pdo-pgsql');
+		$result = Morse::featureExists(Morse::FEATURE_DB_PDO_PGSQL);
 		$this->assertTrue($result===true || $result===false);
 	}
 }

--- a/tests/FileTest.php
+++ b/tests/FileTest.php
@@ -6,13 +6,13 @@ class FileTest extends PHPUnit_Framework_TestCase
 {
 	public function testFinfo()
 	{
-		$result = Morse::featureExists('file/finfo');
+		$result = Morse::featureExists(Morse::FEATURE_FILE_FINFO);
 		$this->assertTrue($result===Morse::CLASS_SUPPORT || $result===Morse::FUNCTION_SUPPORT || $result===false);
 	}
 
 	public function testZip()
 	{
-		$result = Morse::featureExists('file/zip');
+		$result = Morse::featureExists(Morse::FEATURE_FILE_ZIP);
 		$this->assertTrue($result===true || $result===false);
 	}
 

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -6,25 +6,25 @@ class HttpTest extends PHPUnit_Framework_TestCase
 {
 	public function testCurl()
 	{
-		$result = Morse::featureExists('http/curl');
+		$result = Morse::featureExists(Morse::FEATURE_HTTP_CURL);
 		$this->assertTrue($result===true || $result===false);
 	}
 
 	public function testSockets()
 	{
-		$result = Morse::featureExists('http/sockets');
+		$result = Morse::featureExists(Morse::FEATURE_HTTP_SOCKETS);
 		$this->assertTrue($result===true || $result===false);
 	}
 
 	public function testFilter()
 	{
-		$result = Morse::featureExists('http/filter');
+		$result = Morse::featureExists(Morse::FEATURE_HTTP_FILTER);
 		$this->assertTrue($result===true || $result===false);
 	}
 
 	public function testOpenssl()
 	{
-		$result = Morse::featureExists('http/openssl');
+		$result = Morse::featureExists(Morse::FEATURE_HTTP_OPENSSL);
 		$this->assertTrue($result===true || $result===false);
 	}
 }

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -6,13 +6,13 @@ class ImageTest extends PHPUnit_Framework_TestCase
 {
 	public function testGd()
 	{
-		$result = Morse::featureExists('image/gd');
+		$result = Morse::featureExists(Morse::FEATURE_IMAGE_GD);
 		$this->assertTrue($result===true || $result===false);
 	}
 
 	public function testImagick()
 	{
-		$result = Morse::featureExists('image/imagick');
+		$result = Morse::featureExists(Morse::FEATURE_IMAGE_IMAGICK);
 		$this->assertTrue($result===true || $result===false);
 	}
 

--- a/tests/NumberTest.php
+++ b/tests/NumberTest.php
@@ -6,7 +6,7 @@ class NumberTest extends PHPUnit_Framework_TestCase
 {
 	public function testMultibyte()
 	{
-		$result = Morse::featureExists('number/bigint');
+		$result = Morse::featureExists(Morse::FEATURE_NUMBER_BIGINT);
 		$this->assertTrue($result===true || $result===false);
 	}
 

--- a/tests/ProtocolTest.php
+++ b/tests/ProtocolTest.php
@@ -6,7 +6,7 @@ class ProtocolTest extends PHPUnit_Framework_TestCase
 {
 	public function testLdap()
 	{
-		$result = Morse::featureExists('protocol/ldap');
+		$result = Morse::featureExists(Morse::FEATURE_PROTOCOL_LDAP);
 		$this->assertTrue($result===true || $result===false);
 	}
 }

--- a/tests/StringTest.php
+++ b/tests/StringTest.php
@@ -6,37 +6,37 @@ class StringTest extends PHPUnit_Framework_TestCase
 {
 	public function testMultibyte()
 	{
-		$result = Morse::featureExists('string/multibyte');
+		$result = Morse::featureExists(Morse::FEATURE_STRING_MULTIBYTE);
 		$this->assertTrue($result===true || $result===false);
 	}
 
 	public function testTransliterate()
 	{
-		$result = Morse::featureExists('string/transliterate');
+		$result = Morse::featureExists(Morse::FEATURE_STRING_TRANSLITERATE);
 		$this->assertTrue($result===Morse::CLASS_SUPPORT || $result===Morse::FUNCTION_SUPPORT || $result===false);
 	}
 
 	public function testJson()
 	{
-		$result = Morse::featureExists('string/json');
+		$result = Morse::featureExists(Morse::FEATURE_STRING_JSON);
 		$this->assertTrue($result===true || $result===false);
 	}
 
 	public function testIconv()
 	{
-		$result = Morse::featureExists('string/iconv');
+		$result = Morse::featureExists(Morse::FEATURE_STRING_ICONV);
 		$this->assertTrue($result===true || $result===false);
 	}
 
 	public function testCtype()
 	{
-		$result = Morse::featureExists('string/ctype');
+		$result = Morse::featureExists(Morse::FEATURE_STRING_CTYPE);
 		$this->assertTrue($result===true || $result===false);
 	}
 
 	public function testIntl()
 	{
-		$result = Morse::featureExists('string/intl');
+		$result = Morse::featureExists(Morse::FEATURE_STRING_INTL);
 		$this->assertTrue($result===true || $result===false);
 	}
 }

--- a/tests/SystemTest.php
+++ b/tests/SystemTest.php
@@ -6,55 +6,55 @@ class SystemTest extends PHPUnit_Framework_TestCase
 {
 	public function testExec()
 	{
-		$result = Morse::featureExists('system/exec');
+		$result = Morse::featureExists(Morse::FEATURE_SYSTEM_EXEC);
 		$this->assertTrue($result===true || $result===false);
 	}
 
 	public function testShell_exec()
 	{
-		$result = Morse::featureExists('system/shell_exec');
+		$result = Morse::featureExists(Morse::FEATURE_SYSTEM_SHELL_EXEC);
 		$this->assertTrue($result===true || $result===false);
 	}
 
 	public function testIni_set()
 	{
-		$result = Morse::featureExists('system/ini_set');
+		$result = Morse::featureExists(Morse::FEATURE_SYSTEM_INI_SET);
 		$this->assertTrue($result===true || $result===false);
 	}
 
 	public function testSet_time_limit()
 	{
-		$result = Morse::featureExists('system/set_time_limit');
+		$result = Morse::featureExists(Morse::FEATURE_SYSTEM_SET_TIME_LIMIT);
 		$this->assertTrue($result===true || $result===false);
 	}
 
 	public function testIgnore_user_abort()
 	{
-		$result = Morse::featureExists('system/ignore_user_abort');
+		$result = Morse::featureExists(Morse::FEATURE_SYSTEM_IGNORE_USER_ABORT);
 		$this->assertTrue($result===true || $result===false);
 	}
 
 	public function testPassthru()
 	{
-		$result = Morse::featureExists('system/passthru');
+		$result = Morse::featureExists(Morse::FEATURE_SYSTEM_PASSTHRU);
 		$this->assertTrue($result===true || $result===false);
 	}
 
 	public function testSystem()
 	{
-		$result = Morse::featureExists('system/system');
+		$result = Morse::featureExists(Morse::FEATURE_SYSTEM_SYSTEM);
 		$this->assertTrue($result===true || $result===false);
 	}
 
 	public function testPopen()
 	{
-		$result = Morse::featureExists('system/popen');
+		$result = Morse::featureExists(Morse::FEATURE_SYSTEM_POPEN);
 		$this->assertTrue($result===true || $result===false);
 	}
 
 	public function testProc_open()
 	{
-		$result = Morse::featureExists('system/proc_open');
+		$result = Morse::featureExists(Morse::FEATURE_SYSTEM_PROC_OPEN);
 		$this->assertTrue($result===true || $result===false);
 	}
 


### PR DESCRIPTION
I added all current available feature detections as a constant on the Morse class. This allows an IDE to auto complete to easily find a feature. As this library will grow something like this seems to be necessary. This will allow:

    if (Morse::featureExists(Morse::FEATURE_FILE_FINFO)) {
        ...
    }

I also added a test class which will check all available feature detections to ensure a constant with the correct name is available and has the correct value
